### PR TITLE
Use api key names for signed search keys rather than ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,7 @@ try {
 ## Running Tests
 
 ```bash
-ST_APP_SEARCH_HOST_KEY=YOUR_HOST_KEY
-ST_APP_SEARCH_API_KEY=YOUR_API_KEY
-gradle test
+ST_APP_SEARCH_HOST_KEY="YOUR_HOST_KEY" ST_APP_SEARCH_API_KEY="YOUR_API_KEY" gradle test
 ```
 
 ## Contributions

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 }
 
 // Remember to also update version in src/main/java/com/swiftype/appsearch/Client.java!
-version = "0.1.0"
+version = "0.1.1"
 
 apply plugin: 'java'
 

--- a/src/main/java/com/swiftype/appsearch/Client.java
+++ b/src/main/java/com/swiftype/appsearch/Client.java
@@ -28,7 +28,7 @@ import com.google.gson.reflect.TypeToken;
  */
 public class Client {
   // Remember to also update version in build.gradle!
-  private final String VERSION = "0.1.0";
+  private final String VERSION = "0.1.1";
 
   private final String baseUrl;
   private final String apiKey;
@@ -189,15 +189,15 @@ public class Client {
   /**
    * Creates a jwt search key that can be used for authentication to enforce a set of required search options.
    *
-   * @param apiKeyId the unique API Key identifier
+   * @param apiKeyName the unique name for the API Key
    * @param options see the <a href="https://swiftype.com/documentation/app-search/">App Search API</a> for supported search options
    * @return jwt search key
    * @throws InvalidKeyException if the api key is invalid
    */
-  public static String createSignedSearchKey(String apiKey, String apiKeyId, Map<String, Object> options) throws InvalidKeyException {
+  public static String createSignedSearchKey(String apiKey, String apiKeyName, Map<String, Object> options) throws InvalidKeyException {
     Map<String, Object> payload = new HashMap<>();
     payload.putAll(options);
-    payload.put("api_key_id", apiKeyId);
+    payload.put("api_key_name", apiKeyName);
     return Jwt.sign(apiKey, payload);
   }
 

--- a/src/test/java/com/swiftype/appsearch/ClientTest.java
+++ b/src/test/java/com/swiftype/appsearch/ClientTest.java
@@ -28,8 +28,8 @@ class ClientTest {
     engineName = Optional.ofNullable(System.getenv("ST_APP_SEARCH_TEST_ENGINE_NAME"))
       .orElse("java-client-test-engine");
 
-    assertNotNull(hostKey);
-    assertNotNull(apiKey);
+    assertNotNull(hostKey, "Missing required env variable: ST_APP_SEARCH_HOST_KEY");
+    assertNotNull(apiKey, "Missing required env variable: ST_APP_SEARCH_API_KEY");
 
     client = new Client(hostKey, apiKey);
 
@@ -49,12 +49,12 @@ class ClientTest {
     Map<String, Object> options = new HashMap<>();
     options.put("query", "cat");
 
-    String signedKey = Client.createSignedSearchKey("api-mu75psc5egt9ppzuycnc2mc3", "42", options);
+    String signedKey = Client.createSignedSearchKey("api-mu75psc5egt9ppzuycnc2mc3", "my-token-name", options);
 
     Map<String, Object> decodedPayload = Jwt.verify("api-mu75psc5egt9ppzuycnc2mc3", signedKey);
 
     assertEquals(2, decodedPayload.size());
-    assertEquals("42", decodedPayload.get("api_key_id"));
+    assertEquals("my-token-name", decodedPayload.get("api_key_name"));
     assertEquals("cat", decodedPayload.get("query"));
   }
 
@@ -144,10 +144,8 @@ class ClientTest {
 
   @Test
   void invalidDocumentException() throws ClientException {
-    Map<String, Object> innerField = new HashMap<>();
-    innerField.put("no", "nested objects");
     Map<String, Object> document = new HashMap<>();
-    document.put("bad", innerField);
+    document.put("bad_field_name_because_this_key_value_is_really_really_really_long_almost_too_long_to_where_it_makes_you_uncomfortable_and_you_want_to_stop_reading_but_you_cant_so_you_just_keep_going", "foo");
 
     client.createEngine(engineName);
     assertThrows(InvalidDocumentException.class,

--- a/src/test/java/com/swiftype/appsearch/JwtTest.java
+++ b/src/test/java/com/swiftype/appsearch/JwtTest.java
@@ -15,18 +15,18 @@ class JwtTest {
     String signedKey = Jwt.sign(
       "api-mu75psc5egt9ppzuycnc2mc3",
       "{\"typ\":\"JWT\",\"alg\":\"HS256\"}",
-      "{\"query\":\"cat\",\"api_key_id\":\"42\"}"
+      "{\"query\":\"cat\",\"api_key_name\":\"my-token-name\"}"
     );
 
     assertEquals(
-      "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJxdWVyeSI6ImNhdCIsImFwaV9rZXlfaWQiOiI0MiJ9.MSSucKMyjKrqXQeEMeVzCyjHLm32Z66wr_dQ3IITYgY",
+      "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJxdWVyeSI6ImNhdCIsImFwaV9rZXlfbmFtZSI6Im15LXRva2VuLW5hbWUifQ.hhdpalMFuWwuhsVBpHr9piQpg9ISo7xkxp0vSe8Fb50",
       signedKey
     );
 
     Map<String, Object> decodedPayload = Jwt.verify("api-mu75psc5egt9ppzuycnc2mc3", signedKey);
 
     assertEquals(2, decodedPayload.size());
-    assertEquals("42", decodedPayload.get("api_key_id"));
+    assertEquals("my-token-name", decodedPayload.get("api_key_name"));
     assertEquals("cat", decodedPayload.get("query"));
 
     assertThrows(SignatureException.class, () -> {


### PR DESCRIPTION
This is a breaking change.

We're going to stop exposing API Key id's in the dashboard, and rely on the `name` attribute instead.