### PR TITLE
Implements new naming convention for Client parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The latest builds can be found here: https://github.com/swiftype/swiftype-app-se
 
 Run:
 
-    ST_APP_SEARCH_HOST_KEY="YOUR_HOST_KEY" ST_APP_SEARCH_API_KEY="YOUR_API_KEY" gradle build shadowjar
+    ST_APP_SEARCH_HOST_IDENTIFIER="YOUR_HOST_IDENTIFIER" ST_APP_SEARCH_API_KEY="YOUR_API_KEY" gradle build shadowjar
 
 This will generate two jars. `swiftype-app-search-<version>-all.jar` includes all necessary
 dependencies and `swiftype-app-search-<version>.jar` includes only the client code.
@@ -19,16 +19,16 @@ dependencies and `swiftype-app-search-<version>.jar` includes only the client co
 
 ### Setup: Configuring the client and authentication
 
-Create a new instance of the Swiftype App Search Client. This requires your `ACCOUNT_HOST_KEY`, which
+Create a new instance of the Swiftype App Search Client. This requires your `HOST_IDENTIFIER`, which
 identifies the unique hostname of the Swiftype API that is associated with your Swiftype account.
 It also requires a valid `API_KEY`, which authenticates requests to the API:
 
 ```java
 import com.swiftype.appsearch.Client;
 
-String accountHostKey = "host-c5s2mj";
+String hostIdentifier = "host-c5s2mj";
 String apiKey = "api-mu75psc5egt9ppzuycnc2mc3";
-Client client = new Client(accountHostKey, apiKey);
+Client client = new Client(hostIdentifier, apiKey);
 ```
 
 ### API Methods
@@ -169,7 +169,7 @@ try {
 ## Running Tests
 
 ```bash
-ST_APP_SEARCH_HOST_KEY="YOUR_HOST_KEY" ST_APP_SEARCH_API_KEY="YOUR_API_KEY" gradle test
+ST_APP_SEARCH_HOST_IDENTIFIER="YOUR_HOST_IDENTIFIER" ST_APP_SEARCH_API_KEY="YOUR_API_KEY" gradle test
 ```
 
 ## Contributions

--- a/src/main/java/com/swiftype/appsearch/Client.java
+++ b/src/main/java/com/swiftype/appsearch/Client.java
@@ -33,22 +33,22 @@ public class Client {
   private final String apiKey;
 
   /**
-   * @param accountHostKey account host key to use for base url
+   * @param hostIdentifier host identifier to use for base url
    * @param apiKey api key to use for authentication
    */
-  public Client(String accountHostKey, String apiKey) {
-    this(accountHostKey, apiKey, "https://%s.api.swiftype.com/api/as/v1/");
+  public Client(String hostIdentifier, String apiKey) {
+    this(hostIdentifier, apiKey, "https://%s.api.swiftype.com/api/as/v1/");
   }
 
   /**
    * Dev only constructor for hitting dev/private endpoints.
    *
-   * @param accountHostKey account host key to use for base url
+   * @param hostIdentifier host identifier to use for base url
    * @param apiKey api key to use for authentication
-   * @param baseUrlFormatString format string to build a custom base url using host key
+   * @param baseUrlFormatString format string to build a custom base url using host identifier
    */
-  public Client(String accountHostKey, String apiKey, String baseUrlFormatString) {
-    this.baseUrl = String.format(baseUrlFormatString, accountHostKey);
+  public Client(String hostIdentifier, String apiKey, String baseUrlFormatString) {
+    this.baseUrl = String.format(baseUrlFormatString, hostIdentifier);
     this.apiKey = apiKey;
   }
 

--- a/src/test/java/com/swiftype/appsearch/ClientTest.java
+++ b/src/test/java/com/swiftype/appsearch/ClientTest.java
@@ -16,22 +16,25 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class ClientTest {
 
-  private String hostKey;
+  private String hostIdentifier;
   private String apiKey;
   private String engineName;
   private Client client;
 
   @BeforeEach
   public void setUp() {
-    hostKey = System.getenv("ST_APP_SEARCH_HOST_KEY");
+    hostIdentifier = System.getenv("ST_APP_SEARCH_HOST_IDENTIFIER") != null
+      ? System.getenv("ST_APP_SEARCH_HOST_IDENTIFIER")
+      : System.getenv("ST_APP_SEARCH_HOST_KEY"); // Deprecated
+
     apiKey = System.getenv("ST_APP_SEARCH_API_KEY");
     engineName = Optional.ofNullable(System.getenv("ST_APP_SEARCH_TEST_ENGINE_NAME"))
         .orElse("java-client-test-engine");
 
-    assertNotNull(hostKey, "Missing required env variable: ST_APP_SEARCH_HOST_KEY");
+    assertNotNull(hostIdentifier, "Missing required env variable: ST_APP_SEARCH_HOST_IDENTIFIER");
     assertNotNull(apiKey, "Missing required env variable: ST_APP_SEARCH_API_KEY");
 
-    client = new Client(hostKey, apiKey);
+    client = new Client(hostIdentifier, apiKey);
 
     try {
       client.destroyEngine(engineName);
@@ -41,7 +44,7 @@ class ClientTest {
 
   @Test
   void testBaseUrl() {
-    assertEquals(String.format("https://%s.api.swiftype.com/api/as/v1/", hostKey), client.baseUrl());
+    assertEquals(String.format("https://%s.api.swiftype.com/api/as/v1/", hostIdentifier), client.baseUrl());
   }
 
   @Test


### PR DESCRIPTION
- Renamed `apiHostKey` to `hostIdentifier` in all documentation
- Renamed `ST_APP_SEARCH_HOST_KEY` variable used in test to
  `ST_APP_SEARCH_HOST_IDENTIFIER`, with fallback for backwards
  compatibility.