### PR TITLE
Updated reporting headers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 }
 
 // Remember to also update version in src/main/java/com/swiftype/appsearch/Client.java!
-version = "0.2.0"
+version = "0.3.0"
 
 apply plugin: 'java'
 

--- a/src/main/java/com/swiftype/appsearch/Client.java
+++ b/src/main/java/com/swiftype/appsearch/Client.java
@@ -27,7 +27,7 @@ import com.google.gson.reflect.TypeToken;
  */
 public class Client {
   // Remember to also update version in build.gradle!
-  private final String VERSION = "0.2.0";
+  private final String VERSION = "0.3.0";
 
   private final String baseUrl;
   private final String apiKey;

--- a/src/main/java/com/swiftype/appsearch/Client.java
+++ b/src/main/java/com/swiftype/appsearch/Client.java
@@ -229,7 +229,8 @@ public class Client {
 
       try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
         HttpDynamicRequestWithBody request = new HttpDynamicRequestWithBody(httpMethod, baseUrl + path);
-        request.setHeader(HttpHeaders.USER_AGENT, String.format("swiftype-app-search-java/%s", VERSION));
+        request.setHeader("X-Swiftype-Client", "swiftype-app-search-java");
+        request.setHeader("X-Swiftype-Client-Version", VERSION);
         request.setHeader(HttpHeaders.AUTHORIZATION, String.format("Bearer %s", apiKey));
         request.setHeader(HttpHeaders.CONTENT_TYPE, "application/json");
 


### PR DESCRIPTION
[ENG-1107] Clients should send a header with Client type and version

Fixes #12

This lets us more accurately report on client type and version. It also
keeps the User-Agent header free for whatever the platforms
natural User-Agent value is.

I couldn't figure out a good way to verify that the headers are being sent in our current testing setup. I don't think it's critical, however. Long term, I believe we will replace a large portion of this with a generated client.