### PR TITLE
Fix characeter encoding

### DIFF
--- a/src/main/java/com/swiftype/appsearch/Client.java
+++ b/src/main/java/com/swiftype/appsearch/Client.java
@@ -285,7 +285,8 @@ public class Client {
         try (CloseableHttpResponse response = httpClient.execute(request)) {
           int statusCode = response.getStatusLine().getStatusCode();
           if (statusCode < 200 || statusCode > 299) {
-            throw new ClientException(String.format("Error: %d", statusCode));
+            String respBody = EntityUtils.toString(response.getEntity());
+            throw new ClientException(String.format("Error: %d %s", statusCode, respBody));
           }
           String respBody = EntityUtils.toString(response.getEntity());
           return new Gson().fromJson(respBody, resultType.getType());

--- a/src/main/java/com/swiftype/appsearch/Client.java
+++ b/src/main/java/com/swiftype/appsearch/Client.java
@@ -279,7 +279,7 @@ public class Client {
         request.setHeader(HttpHeaders.CONTENT_TYPE, "application/json");
 
         if (reqBody != null) {
-          request.setEntity(new StringEntity(reqBody));
+          request.setEntity(new StringEntity(reqBody, "UTF-8"));
         }
 
         try (CloseableHttpResponse response = httpClient.execute(request)) {

--- a/src/main/java/com/swiftype/appsearch/Client.java
+++ b/src/main/java/com/swiftype/appsearch/Client.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.http.Consts;
 import org.apache.http.HttpHeaders;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
@@ -279,7 +280,7 @@ public class Client {
         request.setHeader(HttpHeaders.CONTENT_TYPE, "application/json");
 
         if (reqBody != null) {
-          request.setEntity(new StringEntity(reqBody, "UTF-8"));
+          request.setEntity(new StringEntity(reqBody, Consts.UTF_8));
         }
 
         try (CloseableHttpResponse response = httpClient.execute(request)) {


### PR DESCRIPTION
This resolves an issue reported outside of Github.

When trying to index a document with content that included the latin character é, an error was being returned from the server:

```
400
Invalid JSON encoding
```

We were using the default encoding provided by the Apache HTTP client's StringEntity, which apparently ISO-8859-1. I think when working with strictly English language characters, it can be interpreted OK as UTF-8, which is why this problem probably went unnoticed.

I've also started printing out the response body along with the http status code on ClientException messages, which otherwise are completely unhelpful.